### PR TITLE
parrot Chrome 62 ClientHello

### DIFF
--- a/tapdance/conn_raw.go
+++ b/tapdance/conn_raw.go
@@ -259,14 +259,13 @@ func (tdRaw *tdRawConn) establishTLStoDecoy() (err error) {
 		Logger().Infoln(tdRaw.idStr() + ": SNI was nil. Setting it to" +
 			config.ServerName)
 	}
-	tdRaw.tlsConn = tls.UClient(dialConn, &config, tls.HelloRandomizedNoALPN)
+  // parrot Chrome 62 ClientHello
+	tdRaw.tlsConn = tls.UClient(dialConn, &config, tls.HelloChrome_62)
 	err = tdRaw.tlsConn.BuildHandshakeState()
 	if err != nil {
 		dialConn.Close()
 		return
 	}
-	tdRaw.tlsConn.HandshakeState.Hello.CipherSuites =
-		forceSupportedCiphersFirst(tdRaw.tlsConn.HandshakeState.Hello.CipherSuites)
 	err = tdRaw.tlsConn.MarshalClientHello()
 	if err != nil {
 		dialConn.Close()


### PR DESCRIPTION
We need a non-randomized ClientHello so that we can predict which over destinations will choose ciphers that we can support. Chrome62 works well, though its fraction in real traffic is gradually waning. 