### PR TITLE
Add 0xc030 as a supported TLS cipher

### DIFF
--- a/tapdance/common.go
+++ b/tapdance/common.go
@@ -122,6 +122,7 @@ var tapDanceSupportedCiphers = []uint16{
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 }
 
 func forceSupportedCiphersFirst(suites []uint16) []uint16 {


### PR DESCRIPTION
This gives us ~500 more decoys over Merit. We can probably add a couple more GCM cipher suites since they _will_ work, but this is the popular one.