### PR TITLE
Faster connects

### DIFF
--- a/tapdance/common.go
+++ b/tapdance/common.go
@@ -3,7 +3,6 @@ package tapdance
 import (
 	"errors"
 	"github.com/refraction-networking/utls"
-	"math"
 	"strconv"
 	"time"
 )
@@ -129,9 +128,8 @@ var tapDanceSupportedCiphers = []uint16{
 
 // How much time to sleep on trying to connect to decoys to prevent overwhelming them
 func sleepBeforeConnect(attempt int) (waitTime <-chan time.Time) {
-	if attempt >= 2 { // return nil for first 2 attempts
-		waitTime = time.After(time.Second *
-			time.Duration(math.Pow(3, float64(attempt-1))))
+	if attempt >= 6 { // return nil for first 6 attempts
+		waitTime = time.After(time.Second * 1)
 	}
 	return
 }

--- a/tapdance/conn_raw.go
+++ b/tapdance/conn_raw.go
@@ -80,11 +80,11 @@ func (tdRaw *tdRawConn) dial(ctx context.Context, reconnect bool) error {
 	*/
 	var expectedTransition pb.S2C_Transition
 	if reconnect {
-		maxConnectionAttempts = 2
+		maxConnectionAttempts = 5
 		expectedTransition = pb.S2C_Transition_S2C_CONFIRM_RECONNECT
 		tdRaw.tlsConn.Close()
 	} else {
-		maxConnectionAttempts = 6
+		maxConnectionAttempts = 20
 		expectedTransition = pb.S2C_Transition_S2C_SESSION_INIT
 	}
 
@@ -128,6 +128,8 @@ func (tdRaw *tdRawConn) dial(ctx context.Context, reconnect bool) error {
 func (tdRaw *tdRawConn) tryDialOnce(ctx context.Context, expectedTransition pb.S2C_Transition) (err error) {
 	Logger().Infoln(tdRaw.idStr() + " Attempting to connect to decoy " +
 		tdRaw.decoySpec.GetHostname() + " (" + tdRaw.decoySpec.GetIpv4AddrStr() + ")")
+
+	connect_start := time.Now()
 	err = tdRaw.establishTLStoDecoy(ctx)
 	if err != nil {
 		Logger().Errorf(tdRaw.idStr() + " establishTLStoDecoy(" +
@@ -135,8 +137,9 @@ func (tdRaw *tdRawConn) tryDialOnce(ctx context.Context, expectedTransition pb.S
 			") failed with " + err.Error())
 		return err
 	}
+	connect_time := time.Since(connect_start)
 	Logger().Infof(tdRaw.idStr() + " Connected to decoy " +
-		tdRaw.decoySpec.GetHostname() + " (" + tdRaw.decoySpec.GetIpv4AddrStr() + ")")
+		tdRaw.decoySpec.GetHostname() + " (" + tdRaw.decoySpec.GetIpv4AddrStr() + ") in " + connect_time.String())
 
 	if tdRaw.IsClosed() {
 		// if connection was closed externally while in establishTLStoDecoy()
@@ -163,9 +166,6 @@ func (tdRaw *tdRawConn) tryDialOnce(ctx context.Context, expectedTransition pb.S
 		return err
 	}
 
-	tdRaw.tlsConn.SetDeadline(time.Now().Add(
-		getRandomDuration(deadlineConnectTDStationMin, deadlineConnectTDStationMax)))
-
 	var tdRequest string
 	tdRequest, err = tdRaw.prepareTDRequest(tdRaw.tagType)
 	if err != nil {
@@ -189,6 +189,9 @@ func (tdRaw *tdRawConn) tryDialOnce(ctx context.Context, expectedTransition pb.S
 
 	switch tdRaw.tagType {
 	case tagHttpGetIncomplete:
+
+		// Give up waiting for the station pretty quickly (2x handshake time == ~4RTT)
+		tdRaw.tlsConn.SetDeadline(time.Now().Add(connect_time * 2))
 		tdRaw.initialMsg, err = tdRaw.readProto()
 		if err != nil {
 			if errIsTimeout(err) {
@@ -214,6 +217,11 @@ func (tdRaw *tdRawConn) tryDialOnce(ctx context.Context, expectedTransition pb.S
 			}
 			return
 		}
+
+		// Update the timeout to something random
+		tdRaw.tlsConn.SetDeadline(time.Now().Add(
+			getRandomDuration(deadlineConnectTDStationMin, deadlineConnectTDStationMax)))
+
 		if tdRaw.initialMsg.GetStateTransition() != expectedTransition {
 			err = errors.New("Init error: state transition mismatch!" +
 				" Received: " + tdRaw.initialMsg.GetStateTransition().String() +


### PR DESCRIPTION
Give up faster on station not picking up (2*handshake_time), and have less aggressive backoff (1 second timeout after 6 failures).

This is to handle the fact that most decoys seem to not yield a station on path. More work to be done to determine if these decoys are just never on paths for people, or on for some/not for others.