### PR TITLE
Build Psiphon ConsoleClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.11"
+  - "1.10"
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ addons:
 install:
   - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
   - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
+  - go get github.com/kardianos/govendor
+  - cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...
 
 script:
-  - cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...
   - go build -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   artifacts: true
 
 install:
+  - go get -d ./...
   - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
   - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
   - go get github.com/kardianos/govendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,33 @@
 language: go
 
 go:
-  - "1.11"
+ - "1.9"
+ - "1.10"
 
 addons:
   artifacts: true
 
+before_install:
+ - sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev libx11-dev
+
+sudo: required
+dist: trusty
+
 install:
-  - go get -d ./...
+  - go get -t ./...
+  - go get github.com/golang/lint/golint
+  # Install gometalinter
+  - go get github.com/alecthomas/gometalinter
+  # Get Psiphon code
   - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
   - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
   - go get github.com/kardianos/govendor
   - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
 
 script:
-  - go build -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+ - go test -race -v ./tapdance/
+ - go test -race -v ./tdproxy/
+ - gometalinter --install
+ - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance/
+ # Build Psiphon ConsoleClient
+ - go build -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ dist: trusty
 
 addons:
   artifacts: true
-
-before_install:
-  - sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev libx11-dev
+  apt:
+    packages:
+      - libegl1-mesa-dev
+      - libgles2-mesa-dev
+      - libx11-dev
 
 install:
   - go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
   - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
   - go get github.com/kardianos/govendor
-  - cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...
+  - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
 
 script:
   - go build -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,10 @@
 language: go
 
 go:
- - "1.9"
- - "1.10"
-
-before_install:
- - sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev libx11-dev
-
-sudo: required
-dist: trusty
+  - "1.11"
 
 install:
-  - go get -t ./...
-  - go get github.com/golang/lint/golint
-  # Install gometalinter
-  - go get github.com/alecthomas/gometalinter
+  - go get -d github.com/Psiphon-Labs/psiphon-tunnel-core
 
 script:
- - go test -race -v ./tapdance/
- - go test -race -v ./tdproxy/
- - gometalinter --install
- - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance/
+  - go build -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: go
 
 go:
- - "1.9"
- - "1.10"
+  - "1.11"
+
+os:
+  - linux
+  - osx
+
+sudo: required
+dist: trusty
 
 addons:
   artifacts: true
 
 before_install:
- - sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev libx11-dev
-
-sudo: required
-dist: trusty
+  - sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev libx11-dev
 
 install:
   - go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
   - go get github.com/kardianos/govendor
   - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
+  - sed -i -e 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
 
 script:
  - go test -race -v ./tapdance/
@@ -30,4 +31,4 @@ script:
  - gometalinter --install
  - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance/
  # Build Psiphon ConsoleClient
- - go build -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+ - go build -race -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ go:
   - "1.11"
 
 addons:
-  artifacts:
-    s3_region: "us-east-2"
+  artifacts: true
 
 install:
   - mkdir -p $GOPATH/src/github.com/Psiphon-Labs

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ go:
   - "1.11"
 
 install:
-  - go get -d github.com/Psiphon-Labs/psiphon-tunnel-core
+  - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
+  - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
 
 script:
   - go build -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ install:
   - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
 
 script:
+  - cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...
   - go build -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 go:
   - "1.11"
 
+addons:
+  artifacts:
+    s3_region: "us-east-2"
+
 install:
   - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
   - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core


### PR DESCRIPTION
Checkout github.com/Psiphon-Labs/psiphon-tunnel-core and build ConsoleClient using our version of gotapdance with logging enabled. Also deprecate Go 1.9 and build for OS X. 