### PR TITLE
Speed up CI test and build pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - sed -i.bak "s/import go\.psi\.Psi;/import psi\.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/psi\.PsiphonProvider/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/psi\.PsiphonProvider\.stub/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelMTU/Psi\.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelDNSResolverIPv4Address/Psi\.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.Start(/Psi\.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,6 @@ jobs:
 
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
-      language: android
-
       before_script:
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
@@ -85,7 +83,7 @@ jobs:
         - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
       script:
         # Build Psiphon Android Library ca.psiphon.aar
-    #     - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")
+        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")
     #     - mv $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/ca.psiphon.aar build/
     #     # Build Psiphon Android App PsiphonAndroid-debug.apk
     #     - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
   - PATH=$HOME/.local/bin:$PATH
 
 cache:
+  pip: true
   directories:
     - $HOME/.gimme
     - $TRAVIS_HOME/go
     - $TRAVIS_HOME/android
     - $HOME/.gradle
-    - $HOME/.cache/pip
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,4 +112,6 @@ jobs:
         - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug)
         - mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/
+        - rm $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/ca.psiphon.aar
         - rm -r $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build
+        - rm -rf $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - sed -i.bak "s/import go\.psi\.Psi;/import psi\.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/psi\.PsiphonProvider\.stub/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/Psi\.PsiphonProvider/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelMTU/Psi\.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelDNSResolverIPv4Address/Psi\.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.Start(/Psi\.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
   directories:
     - $TRAVIS_HOME/go
 before_install:
+  - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"; fi
   - export GOPATH=$TRAVIS_HOME/go
   - export PATH=$GOPATH/bin:$PATH
   - mkdir -p $GOPATH/src/github.com/sergeyfrolov

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ jobs:
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git checkout 320ec40f6328971c405979b804e20d5f3c86770c)
         - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
+        - sed -i.bak "s/df8492a31030c4a940aa17602ea7ce56eb0759be9235f68fcce4c51150e49881/84c9361734902df622dd49a8c0cfb0090fd7743a2cbf927a9ae85c4826beb173/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - go install golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ go:
   - "1.10.x"
   - "1.x"
 
-env:
-  # For pip --user
-  - PATH=$HOME/.local/bin:$PATH
-
 cache:
   pip: true
   directories:
@@ -17,6 +13,7 @@ cache:
     - $TRAVIS_HOME/go
     - $TRAVIS_HOME/android
     - $HOME/.gradle
+    - $HOME/.local
 
 notifications:
   slack:
@@ -74,7 +71,8 @@ jobs:
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
         # Enable TapDance logging
         - sed -i.bak "s/refraction_networking_tapdance\.Logger()\.Out = ioutil\.Discard//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-        - pip install --user awscli
+        - pip install --user --upgrade pip
+        - pip install --user --upgrade awscli
       script:
         - go build -o build/cli-$TRAVIS_OS_NAME ./cli
         - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags "TAPDANCE" github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ cache:
   pip: true
   directories:
     - $TRAVIS_HOME/go
+    - /usr/local/android-sdk
+    - ~/.gradle
 before_install:
   - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"; fi
   - export GOPATH=$TRAVIS_HOME/go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,27 @@
+sudo: required
+dist: xenial
+
 language: go
 go:
   - "1.10.x"
   - "1.x"
 
-sudo: required
-dist: xenial
+env:
+  # For pip --user
+  - PATH=$HOME/.local/bin:$PATH
+
+cache:
+  pip: true
+  directories:
+    - $HOME/.gimme
+    - $TRAVIS_HOME/go
+    - $HOME/.gradle
 
 notifications:
   slack:
     secure: ZzIEqFE4XRdE9U2p3aeE32DMtoC8RgjoEavhEQ1oLrWFgUpLktqmp9UVY/U+W6iElilLpDbFpry51+Sv9MWpxJMxr+Q/JJuq/3Bj5KjF/wEtil7qvBYhQ1sM/qUQFG6wRkrMNjZGMiaTmnkWF0rZB8lf7+nbnGFaPW3AVVbD+8gVDWTHI4Hcvvgs0UbrJzoPfpvH0dprOchswc1BBKTgo5c44rvS2fquEMVcqMMiNJ5JQqphuRWLTfzLgOzImSf0/xJJyVp/YTkSnVSg8BcWmDCJ4iB9fJkVyZM9WxcgY/J4T5VzFxfMah9zv2j8UTfzHSMeCJDRL647hdnkmr/Qum/LN91Ey2DJw5KUH743CsAbyGhQML6wZ3NCeEP06hnMDphalU5+BYhtAPyc5CB84g6eLIUQ2EqptuPZpjFQohFnapCTnfB5XKTcW+PjxJsoJzk8x+85Xid+H1nnNxeyf10tLv6Pwy4ZGmEEbsa4SYWXibpIEu3fPJXEdtrht0vM40pDLeUYL6Axmh7hNjmDQOXJG41saF+Rk4AArRhKhMQTmlYCc0e1H2/hIDXUMPbqjHeCpEkaA5W8BFBKynhlJa0JX+rtHDFaK82Di8rXT0NO2ACyG8ZQqk87qePyBYPyfR8hRwhrkmQHlYYOZzV6LBz+ynJuWl9ktcC2irJlHZs=
 
-cache:
-  pip: true
-  directories:
-    - $TRAVIS_HOME/go
-    - $HOME/.gradle
+
 before_install:
   # Get Golang in Android environment
   - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"; fi
@@ -31,24 +38,24 @@ before_cache:
   - export TRAVIS_BUILD_DIR=$TRAVIS_HOME/tmp
   - cd $TRAVIS_BUILD_DIR
 
+
 ## gotapdance tests
 # Go versions: all specified
 install:
   - go get -d -u -t ./...
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/alecthomas/gometalinter
-
 script:
   - go test -race -v ./tapdance
   - go test -race -v ./tdproxy
   - gometalinter --install
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
+
 jobs:
   include:
     ## Build cli, Psiphon ConsoleClient and Android app
     # Go versions: first value in list
-
     - &build # YAML anchor/alias
       stage: build
       name: "Build cli and Psiphon ConsoleClient on Linux"
@@ -77,8 +84,8 @@ jobs:
 
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
-      language: android
       dist: trusty # xenial not available
+      language: android
       android:
         components:
           - tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
         - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
       after_success:
         # Upload built binaries to S3
-        - pip install awscli
+        - pip install --user -U awscli
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
 
     # - <<: *build # Same build on OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
         - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
       after_success:
         # Upload built binaries to S3
-        - pip install --user -U awscli
+        - pip install --user awscli
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
 
     # - <<: *build # Same build on OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: generic
+
 sudo: required
 dist: xenial
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,6 @@ jobs:
         - yes | sdkmanager "ndk-bundle"
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git checkout 320ec40f6328971c405979b804e20d5f3c86770c)
-        - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - go install golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ cache:
   directories:
     - $GOPATH
 before_cache:
-  - mv ${TRAVIS_BUILD_DIR} ${TRAVIS_HOME}/tmp
+  - cp -r ${TRAVIS_BUILD_DIR} ${TRAVIS_HOME}/tmp
+  - rm -r ${TRAVIS_BUILD_DIR}
   - export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/tmp
   - cd ${TRAVIS_BUILD_DIR}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,3 +110,4 @@ jobs:
         - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug)
         - mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/
+        - rm -r $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,16 @@ notifications:
 
 cache:
   directories:
-    - $GOPATH
+    - $GOPATH/src
+before_cache:
+  - mv ${TRAVIS_BUILD_DIR} ${TRAVIS_HOME}/tmp
+  - export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/tmp
+  - cd ${TRAVIS_BUILD_DIR}
 
 ## Golang Test
 # Go versions: all specified
 install:
-  - go get -u -t ./...
+  - go get -d -u -t ./...
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/alecthomas/gometalinter
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 script:
   - go test -race -v ./tapdance
   - go test -race -v ./tdproxy
-  - if [ ! -f "$GOPATH/bin/misspell" ] || [ -f "$GOPATH/bin/ineffassign" ] || [ -f "$GOPATH/bin/deadcode" ]; then gometalinter --install; fi
+  - if [ ! -f "$GOPATH/bin/misspell" ] || [ ! -f "$GOPATH/bin/ineffassign" ] || [ ! -f "$GOPATH/bin/deadcode" ]; then gometalinter --install; fi
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ cache:
   pip: true
   directories:
     - $TRAVIS_HOME/go
-    - /usr/local/android-sdk
-    - ~/.gradle
+    - $HOME/.gradle
 before_install:
   # Get Golang in Android environment
   - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"; fi
@@ -78,6 +77,7 @@ jobs:
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
       language: android
+      dist: trusty # xenial not available
       android:
         components:
           - tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,16 @@ before_cache:
 
 ## Golang Test
 # Go versions: all specified
-# install:
-#   - go get -d -u -t ./...
-#   - go get -u github.com/golang/lint/golint
-#   - go get -u github.com/alecthomas/gometalinter
-#
-# script:
-#   - go test -race -v ./tapdance
-#   - go test -race -v ./tdproxy
-#   - gometalinter --install
-#   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
+install:
+  - go get -d -u -t ./...
+  - go get -u github.com/golang/lint/golint
+  - go get -u github.com/alecthomas/gometalinter
+
+script:
+  - go test -race -v ./tapdance
+  - go test -race -v ./tdproxy
+  - gometalinter --install
+  - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 install: skip
 script: skip
 
@@ -66,10 +66,10 @@ jobs:
         # Upload built binaries to S3
         - pip install --user awscli
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
-    #
-    # - <<: *build # Same build on OS X
-    #   name: "Build cli and Psiphon ConsoleClient on OS X"
-    #   os: osx
+
+    - <<: *build # Same build on OS X
+      name: "Build cli and Psiphon ConsoleClient on OS X"
+      os: osx
 
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
@@ -85,6 +85,7 @@ jobs:
         - yes | sdkmanager "ndk-bundle"
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git checkout 320ec40f6328971c405979b804e20d5f3c86770c)
+        - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - go install golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
@@ -96,8 +97,8 @@ jobs:
       script:
         # Build Psiphon Android Library ca.psiphon.aar
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")
-    #     - mv $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/ca.psiphon.aar build/
-    #     # Build Psiphon Android App PsiphonAndroid-debug.apk
-    #     - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/
-    #     - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android:/go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android refraction/psiandroid /bin/bash -c "yes | /android-sdk-linux/tools/bin/sdkmanager --update && cd /go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug"
-    #     - sudo mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/
+        - mv $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/ca.psiphon.aar build/
+        # Build Psiphon Android App PsiphonAndroid-debug.apk
+        - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/
+        - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug)
+        - mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,8 @@ jobs:
       before_script:
         - yes | sdkmanager "ndk-bundle"
         - go get -d -u golang.org/x/mobile/cmd/gomobile
-        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard d6153aa12bff20a59a59a08b68ecf806b3a60605)
+        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git checkout 320ec40f6328971c405979b804e20d5f3c86770c)
+        - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - go install golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,9 @@ jobs:
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
       language: android
+      android:
+        components:
+          - ndk-bundle
       before_script:
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,12 @@ jobs:
         - yes | sdkmanager "ndk-bundle"
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
-        - sed -i.bak "s/import go.psi.Psi;//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi./psi./g" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/import go.psi.Psi;/import psi.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi.PsiphonProvider.Stub/psi.PsiphonProvider.Stub/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi.GetPacketTunnelMTU/Psi.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi.GetPacketTunnelDNSResolverIPv4Address/Psi.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi.Start(/Psi.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi.Stop();/Psi.stop();/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-language: go
-go:
-  - "1.10.x"
-  - "1.x"
-
 sudo: required
 dist: xenial
 
@@ -11,7 +6,7 @@ notifications:
     secure: ZzIEqFE4XRdE9U2p3aeE32DMtoC8RgjoEavhEQ1oLrWFgUpLktqmp9UVY/U+W6iElilLpDbFpry51+Sv9MWpxJMxr+Q/JJuq/3Bj5KjF/wEtil7qvBYhQ1sM/qUQFG6wRkrMNjZGMiaTmnkWF0rZB8lf7+nbnGFaPW3AVVbD+8gVDWTHI4Hcvvgs0UbrJzoPfpvH0dprOchswc1BBKTgo5c44rvS2fquEMVcqMMiNJ5JQqphuRWLTfzLgOzImSf0/xJJyVp/YTkSnVSg8BcWmDCJ4iB9fJkVyZM9WxcgY/J4T5VzFxfMah9zv2j8UTfzHSMeCJDRL647hdnkmr/Qum/LN91Ey2DJw5KUH743CsAbyGhQML6wZ3NCeEP06hnMDphalU5+BYhtAPyc5CB84g6eLIUQ2EqptuPZpjFQohFnapCTnfB5XKTcW+PjxJsoJzk8x+85Xid+H1nnNxeyf10tLv6Pwy4ZGmEEbsa4SYWXibpIEu3fPJXEdtrht0vM40pDLeUYL6Axmh7hNjmDQOXJG41saF+Rk4AArRhKhMQTmlYCc0e1H2/hIDXUMPbqjHeCpEkaA5W8BFBKynhlJa0JX+rtHDFaK82Di8rXT0NO2ACyG8ZQqk87qePyBYPyfR8hRwhrkmQHlYYOZzV6LBz+ynJuWl9ktcC2irJlHZs=
 
 cache:
-  pip: true
+  # pip: true
   directories:
     - $TRAVIS_HOME/go
 before_install:
@@ -22,9 +17,8 @@ before_install:
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR
 before_cache:
-  - export GOPATH=$TRAVIS_HOME/gopath
-  - mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/sergeyfrolov/gotapdance
-  - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
+  - mv $TRAVIS_BUILD_DIR $TRAVIS_HOME/tmp
+  - export TRAVIS_BUILD_DIR=$TRAVIS_HOME/tmp
   - cd $TRAVIS_BUILD_DIR
 
 ## Golang Test
@@ -42,32 +36,32 @@ script:
 
 ## Build job for CLI, Psiphon ConsoleClient and Android App
 # Go versions: first value in array
-jobs:
-  include:
-    - &build # YAML anchor/alias
-      stage: build
-      name: "Build cli and Psiphon ConsoleClient on Linux"
-      install:
-        - go get -d -u ./...
-        # Substitute build string
-        - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
-        - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-        # Remove gotapdance from vendored packages
-        - go get -u github.com/kardianos/govendor
-        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
-        # Enable TapDance logging
-        - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-      script:
-        - go build -o build/cli-$TRAVIS_OS_NAME ./cli
-        - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-      after_success:
-        # Upload built binaries to S3
-        - pip install --user awscli
-        - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
-
-    - <<: *build # Same build on OS X
-      name: "Build cli and Psiphon ConsoleClient on OS X"
-      os: osx
+# jobs:
+#   include:
+    # - &build # YAML anchor/alias
+    #   stage: build
+    #   name: "Build cli and Psiphon ConsoleClient on Linux"
+    #   install:
+    #     - go get -d -u ./...
+    #     # Substitute build string
+    #     - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
+    #     - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+    #     # Remove gotapdance from vendored packages
+    #     - go get -u github.com/kardianos/govendor
+    #     - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
+    #     # Enable TapDance logging
+    #     - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+    #   script:
+    #     - go build -o build/cli-$TRAVIS_OS_NAME ./cli
+    #     - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+    #   after_success:
+    #     # Upload built binaries to S3
+    #     - pip install --user awscli
+    #     - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
+    #
+    # - <<: *build # Same build on OS X
+    #   name: "Build cli and Psiphon ConsoleClient on OS X"
+    #   os: osx
 
     # - <<: *build # Reuse setup steps from build
     #   name: "Build Psiphon Android Library and App"

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
         - if [ -d "$GOPATH/src/golang.org/x/mobile/cmd/gomobile" ]; then (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard); fi
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         # Freeze gomobile version (newer versions break Psiphon code)
-        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
+        - (cd $GOPATH/src/golang.org/x/mobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
         # Binary hashes has since changed
         - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - sed -i.bak "s/df8492a31030c4a940aa17602ea7ce56eb0759be9235f68fcce4c51150e49881/84c9361734902df622dd49a8c0cfb0090fd7743a2cbf927a9ae85c4826beb173/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR
   # Move Android tools directory
-  - if [ -z "$ANDROID_HOME" ] && [ ! -d "$TRAVIS_HOME/android/tools" ]; then cp -r $ANDROID_HOME/* $TRAVIS_HOME/android/; fi
+  - if [ ! -z "$ANDROID_HOME" ] && [ ! -d "$TRAVIS_HOME/android/tools" ]; then cp -r $ANDROID_HOME/* $TRAVIS_HOME/android/; fi
   - export ANDROID_HOME=$TRAVIS_HOME/android
   - export PATH=$ANDROID_HOME/tools/bin:$PATH
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,9 +86,7 @@ jobs:
       android:
         components:
           - tools
-          - platform-tools
-          - tools
-          - build-tools-28.0.3
+          - tools # Intentional to get latest version
           - android-23
       before_script:
         # Install SDK and accept licenses

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   directories:
     - $TRAVIS_HOME/go
 before_install:
-  - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"; fi
+  - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.9.6 bash)"; fi
   - export GOPATH=$TRAVIS_HOME/go
   - export PATH=$GOPATH/bin:$PATH
   - mkdir -p $GOPATH/src/github.com/sergeyfrolov

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ cache:
     - /usr/local/android-sdk
     - ~/.gradle
 before_install:
+  # Get Golang in Android environment
   - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"; fi
+  # Use cached directory as GOPATH
   - export GOPATH=$TRAVIS_HOME/go
   - export PATH=$GOPATH/bin:$PATH
   - mkdir -p $GOPATH/src/github.com/sergeyfrolov
@@ -25,11 +27,12 @@ before_install:
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR
 before_cache:
+  # Don't cache gotapdance
   - mv $TRAVIS_BUILD_DIR $TRAVIS_HOME/tmp
   - export TRAVIS_BUILD_DIR=$TRAVIS_HOME/tmp
   - cd $TRAVIS_BUILD_DIR
 
-## Golang Test
+## gotapdance tests
 # Go versions: all specified
 install:
   - go get -d -u -t ./...
@@ -41,13 +44,12 @@ script:
   - go test -race -v ./tdproxy
   - gometalinter --install
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
-install: skip
-script: skip
 
-## Build job for CLI, Psiphon ConsoleClient and Android App
-# Go versions: first value in array
 jobs:
   include:
+    ## Build cli, Psiphon ConsoleClient and Android app
+    # Go versions: first value in list
+
     - &build # YAML anchor/alias
       stage: build
       name: "Build cli and Psiphon ConsoleClient on Linux"
@@ -80,16 +82,20 @@ jobs:
         components:
           - tools
           - platform-tools
-          - tools
+          - tools # Intentional to get latest version
           - build-tools-28.0.3
-          - android-23
+          - android-23 # Target API platform
       before_script:
+        # Install NDK and accept licenses
         - yes | sdkmanager "ndk-bundle"
         - go get -d -u golang.org/x/mobile/cmd/gomobile
+        # Freeze gomobile version (newer versions break Psiphon code)
         - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git checkout 320ec40f6328971c405979b804e20d5f3c86770c)
+        # Binary hashes has since changed
         - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - sed -i.bak "s/df8492a31030c4a940aa17602ea7ce56eb0759be9235f68fcce4c51150e49881/84c9361734902df622dd49a8c0cfb0090fd7743a2cbf927a9ae85c4826beb173/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - go install golang.org/x/mobile/cmd/gomobile
+        # Initialize gomobile tool
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
 script:
   - go test -race -v ./tapdance
   - go test -race -v ./tdproxy
-  - gometalinter --install
+  - if [ ! -f "$GOPATH/bin/misspell" ] || [ -f "$GOPATH/bin/ineffassign" ] || [ -f "$GOPATH/bin/deadcode" ]; then gometalinter --install; fi
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 script:
   - go test -race -v ./tapdance
   - go test -race -v ./tdproxy
-  - gometalinter --install
+  - if [ ! -f "$GOPATH/bin/misspell" ] || [ ! -f "$GOPATH/bin/ineffassign" ] || [ ! -f "$GOPATH/bin/deadcode" ]; then gometalinter --install; fi
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
     secure: ZzIEqFE4XRdE9U2p3aeE32DMtoC8RgjoEavhEQ1oLrWFgUpLktqmp9UVY/U+W6iElilLpDbFpry51+Sv9MWpxJMxr+Q/JJuq/3Bj5KjF/wEtil7qvBYhQ1sM/qUQFG6wRkrMNjZGMiaTmnkWF0rZB8lf7+nbnGFaPW3AVVbD+8gVDWTHI4Hcvvgs0UbrJzoPfpvH0dprOchswc1BBKTgo5c44rvS2fquEMVcqMMiNJ5JQqphuRWLTfzLgOzImSf0/xJJyVp/YTkSnVSg8BcWmDCJ4iB9fJkVyZM9WxcgY/J4T5VzFxfMah9zv2j8UTfzHSMeCJDRL647hdnkmr/Qum/LN91Ey2DJw5KUH743CsAbyGhQML6wZ3NCeEP06hnMDphalU5+BYhtAPyc5CB84g6eLIUQ2EqptuPZpjFQohFnapCTnfB5XKTcW+PjxJsoJzk8x+85Xid+H1nnNxeyf10tLv6Pwy4ZGmEEbsa4SYWXibpIEu3fPJXEdtrht0vM40pDLeUYL6Axmh7hNjmDQOXJG41saF+Rk4AArRhKhMQTmlYCc0e1H2/hIDXUMPbqjHeCpEkaA5W8BFBKynhlJa0JX+rtHDFaK82Di8rXT0NO2ACyG8ZQqk87qePyBYPyfR8hRwhrkmQHlYYOZzV6LBz+ynJuWl9ktcC2irJlHZs=
 
 cache:
+  pip: true
   directories:
     - $GOPATH
 before_cache:
@@ -53,7 +54,7 @@ jobs:
         - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
       after_success:
         # Upload built binaries to S3
-        - sudo pip install awscli
+        - pip install awscli
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
 
     # - <<: *build # Same build on OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - sed -i.bak "s/import go\.psi\.Psi;/import psi\.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/Psi\.PsiphonProvider/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/extends Psi\.PsiphonProvider\.Stub/implements psi\.PsiphonProvider/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelMTU/Psi\.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelDNSResolverIPv4Address/Psi\.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.Start(/Psi\.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 
 cache:
   directories:
-    - $GOPATH/src
+    - $GOPATH
 before_cache:
   - mv ${TRAVIS_BUILD_DIR} ${TRAVIS_HOME}/tmp
   - export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
       after_success:
         # Upload built binaries to S3
         - pip install --user awscli
-        - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
+        - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$AWS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
 
     - <<: *build # Same build on OS X
       name: "Build cli and Psiphon ConsoleClient on OS X"

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,8 @@ jobs:
         - yes | sdkmanager "ndk-bundle"
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
-        - sed -i.bak "s/import go.psi.Psi;/import psi.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/import go.psi.Psi;//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi./psi./g" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,14 +83,10 @@ jobs:
           - android-23
       before_script:
         - yes | sdkmanager "ndk-bundle"
-        - go get -u golang.org/x/mobile/cmd/gomobile
+        - go get -d -u golang.org/x/mobile/cmd/gomobile
+        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 74ee969d3ffc95befa9a96a6590c36d71b6afd52)
+        - go install golang.org/x/mobile/cmd/gomobile
         - gomobile init
-        - sed -i.bak "s/import go\.psi\.Psi;/import psi\.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/Psi\.psiphonProvider\.stub/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.GetPacketTunnelMTU/Psi\.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.GetPacketTunnelDNSResolverIPv4Address/Psi\.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.Start(/Psi\.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.Stop();/Psi\.stop();/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
   - "1.10.x"
-  - "1.x"
+  # - "1.x"
 
 sudo: required
 dist: xenial
@@ -33,33 +33,33 @@ script:
 
 ## Build job for CLI, Psiphon ConsoleClient and Android App
 # Go versions: first value in array
-jobs:
-  include:
-    - &build # YAML anchor/alias
-      stage: build
-      name: "Build cli and Psiphon ConsoleClient on Linux"
-      install:
-        - go get -u ./...
-        # Substitute build string
-        - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
-        - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
-        - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
-        # Remove gotapdance from vendored packages
-        - go get -u github.com/kardianos/govendor
-        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
-        # Enable TapDance logging
-        - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-      script:
-        - go build -o build/cli-$TRAVIS_OS_NAME ./cli
-        - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-      after_success:
-        # Upload built binaries to S3
-        - sudo pip install awscli
-        - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
-
-    - <<: *build # Same build on OS X
-      name: "Build cli and Psiphon ConsoleClient on OS X"
-      os: osx
+# jobs:
+#   include:
+    # - &build # YAML anchor/alias
+    #   stage: build
+    #   name: "Build cli and Psiphon ConsoleClient on Linux"
+    #   install:
+    #     - go get -u ./...
+    #     # Substitute build string
+    #     - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
+    #     - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
+    #     - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
+    #     # Remove gotapdance from vendored packages
+    #     - go get -u github.com/kardianos/govendor
+    #     - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
+    #     # Enable TapDance logging
+    #     - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+    #   script:
+    #     - go build -o build/cli-$TRAVIS_OS_NAME ./cli
+    #     - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+    #   after_success:
+    #     # Upload built binaries to S3
+    #     - sudo pip install awscli
+    #     - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
+    #
+    # - <<: *build # Same build on OS X
+    #   name: "Build cli and Psiphon ConsoleClient on OS X"
+    #   os: osx
 
     # - <<: *build # Reuse setup steps from build
     #   name: "Build Psiphon Android Library and App"

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - sed -i.bak "s/import go\.psi\.Psi;/import psi\.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/extends Psi\.PsiphonProvider\.Stub/implements psi\.PsiphonProvider/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/Psi\.psiphonProvider\.stub/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelMTU/Psi\.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelDNSResolverIPv4Address/Psi\.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.Start(/Psi\.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ jobs:
         - yes | sdkmanager "ndk-bundle"
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         # Freeze gomobile version (newer versions break Psiphon code)
-        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git checkout 320ec40f6328971c405979b804e20d5f3c86770c)
+        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
         # Binary hashes has since changed
         - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - sed -i.bak "s/df8492a31030c4a940aa17602ea7ce56eb0759be9235f68fcce4c51150e49881/84c9361734902df622dd49a8c0cfb0090fd7743a2cbf927a9ae85c4826beb173/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,6 @@ jobs:
       language: android
       android:
         components:
-          - tools
-          - tools # Intentional to get latest version
           - android-23
       before_script:
         # Install SDK and accept licenses

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ jobs:
           - platform-tools
           - tools
           - build-tools-28.0.3
-          - android-28
+          - android-23
       before_script:
         - yes | sdkmanager "ndk-bundle"
         - go get -u golang.org/x/mobile/cmd/gomobile

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ jobs:
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
       before_script:
+        - go get -u golang.org/x/mobile/cmd/gomobile
+        - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ go:
   - "1.10.x"
   - "1.x"
 
-dist: xenial
+sudo: required
+dist: bionic
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ go:
   - "1.x"
 
 cache:
-  pip: true
   directories:
-    - $HOME/.gimme
     - $TRAVIS_HOME/go
     - $HOME/.gradle
-    - $HOME/.local
 
 notifications:
   slack:
@@ -66,13 +63,12 @@ jobs:
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
         # Enable TapDance logging
         - sed -i.bak "s/refraction_networking_tapdance\.Logger()\.Out = ioutil\.Discard//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-        - virtualenv -p  .
-        - pip install --user --upgrade awscli
       script:
         - go build -o build/cli-$TRAVIS_OS_NAME ./cli
         - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags "TAPDANCE" github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
       after_success:
         # Upload built binaries to S3
+        - sudo pip install awscli
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$AWS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
 
     - <<: *build # Same build on OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
   - "1.10.x"
-  # - "1.x"
+  - "1.x"
 
 sudo: required
 dist: xenial
@@ -42,32 +42,32 @@ script:
 
 ## Build job for CLI, Psiphon ConsoleClient and Android App
 # Go versions: first value in array
-# jobs:
-#   include:
-    # - &build # YAML anchor/alias
-    #   stage: build
-    #   name: "Build cli and Psiphon ConsoleClient on Linux"
-    #   install:
-    #     - go get -d -u ./...
-    #     # Substitute build string
-    #     - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
-    #     - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-    #     # Remove gotapdance from vendored packages
-    #     - go get -u github.com/kardianos/govendor
-    #     - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
-    #     # Enable TapDance logging
-    #     - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-    #   script:
-    #     - go build -o build/cli-$TRAVIS_OS_NAME ./cli
-    #     - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-    #   after_success:
-    #     # Upload built binaries to S3
-    #     - pip install --user awscli
-    #     - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
+jobs:
+  include:
+    - &build # YAML anchor/alias
+      stage: build
+      name: "Build cli and Psiphon ConsoleClient on Linux"
+      install:
+        - go get -d -u ./...
+        # Substitute build string
+        - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
+        - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+        # Remove gotapdance from vendored packages
+        - go get -u github.com/kardianos/govendor
+        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
+        # Enable TapDance logging
+        - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+      script:
+        - go build -o build/cli-$TRAVIS_OS_NAME ./cli
+        - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+      after_success:
+        # Upload built binaries to S3
+        - pip install --user awscli
+        - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
 
-    # - <<: *build # Same build on OS X
-    #   name: "Build cli and Psiphon ConsoleClient on OS X"
-    #   os: osx
+    - <<: *build # Same build on OS X
+      name: "Build cli and Psiphon ConsoleClient on OS X"
+      os: osx
 
     # - <<: *build # Reuse setup steps from build
     #   name: "Build Psiphon Android Library and App"

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,9 @@ jobs:
           - android-23
       before_script:
         - yes | sdkmanager "ndk-bundle"
-        - export CGO_ENABLED=1
-        - go get -u golang.org/x/mobile/cmd/gomobile
+        - go get -d -u golang.org/x/mobile/cmd/gomobile
+        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
+        - go install golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,8 @@ jobs:
         - yes | sdkmanager "ndk-bundle"
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
+        - mkdir -p $GOPATH/pkg/gomobile/dl
+        - curl -O $GOPATH/pkg/gomobile/dl/gomobile-ndk-r10e-linux-x86_64.tar.gz https://dl.google.com/go/mobile/gomobile-ndk-r10e-linux-x86_64.tar.gz
         - go install golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $GOPATH
 before_cache:
   - cp -r ${TRAVIS_BUILD_DIR} ${TRAVIS_HOME}/tmp
-  - rm -r ${TRAVIS_BUILD_DIR}
+  - rm -rf ${TRAVIS_BUILD_DIR}
   - export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/tmp
   - cd ${TRAVIS_BUILD_DIR}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,5 +113,3 @@ jobs:
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug)
         - mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/
         - rm $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/ca.psiphon.aar
-        - rm -r $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build
-        - rm -rf $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,8 @@ jobs:
         - go install golang.org/x/mobile/cmd/gomobile
         # Initialize gomobile tool
         - gomobile init
-        - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg update --clean)
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
+        - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg update --clean)
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance
         - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,48 +14,48 @@ cache:
   directories:
     - $GOPATH
 before_cache:
-  - echo ${TRAVIS_BUILD_DIR}
-  - rm -rf ${TRAVIS_BUILD_DIR}
+  - mv $TRAVIS_BUILD_DIR $TRAVIS_HOME/tmp
+  - export TRAVIS_BUILD_DIR=$TRAVIS_HOME/tmp
+  - cd $TRAVIS_BUILD_DIR
 
 ## Golang Test
 # Go versions: all specified
-install:
-  - go get -d -u -t ./...
-  - go get -u github.com/golang/lint/golint
-  - go get -u github.com/alecthomas/gometalinter
-
-script:
-  - go test -race -v ./tapdance
-  - go test -race -v ./tdproxy
-  - gometalinter --install
-  - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
+# install:
+#   - go get -d -u -t ./...
+#   - go get -u github.com/golang/lint/golint
+#   - go get -u github.com/alecthomas/gometalinter
+#
+# script:
+#   - go test -race -v ./tapdance
+#   - go test -race -v ./tdproxy
+#   - gometalinter --install
+#   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
 ## Build job for CLI, Psiphon ConsoleClient and Android App
 # Go versions: first value in array
-# jobs:
-#   include:
-    # - &build # YAML anchor/alias
-    #   stage: build
-    #   name: "Build cli and Psiphon ConsoleClient on Linux"
-    #   install:
-    #     - go get -u ./...
-    #     # Substitute build string
-    #     - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
-    #     - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
-    #     - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
-    #     # Remove gotapdance from vendored packages
-    #     - go get -u github.com/kardianos/govendor
-    #     - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
-    #     # Enable TapDance logging
-    #     - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-    #   script:
-    #     - go build -o build/cli-$TRAVIS_OS_NAME ./cli
-    #     - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-    #   after_success:
-    #     # Upload built binaries to S3
-    #     - sudo pip install awscli
-    #     - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
-    #
+jobs:
+  include:
+    - &build # YAML anchor/alias
+      stage: build
+      name: "Build cli and Psiphon ConsoleClient on Linux"
+      install:
+        - go get -d -u ./...
+        # Substitute build string
+        - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
+        - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+        # Remove gotapdance from vendored packages
+        - go get -u github.com/kardianos/govendor
+        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
+        # Enable TapDance logging
+        - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+      script:
+        - go build -o build/cli-$TRAVIS_OS_NAME ./cli
+        - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+      after_success:
+        # Upload built binaries to S3
+        - sudo pip install awscli
+        - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
+
     # - <<: *build # Same build on OS X
     #   name: "Build cli and Psiphon ConsoleClient on OS X"
     #   os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ go:
   - "1.10.x"
   - "1.x"
 
+services:
+  - docker
+
 cache:
+  timeout: 600
   directories:
     - $TRAVIS_HOME/go
-    - $HOME/.gradle
+    - /var/lib/docker
 
 notifications:
   slack:
@@ -17,8 +21,6 @@ notifications:
 
 
 before_install:
-  # Get Golang in Android environment
-  - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"; fi
   # Use cached directory as GOPATH
   - export GOPATH=$TRAVIS_HOME/go
   - export PATH=$GOPATH/bin:$PATH
@@ -53,7 +55,7 @@ jobs:
       stage: build
       name: "Build cli and Psiphon ConsoleClient on Linux"
       env:
-        - STAGE_BUILD=1 # Force separate caches
+        - BUILD_CLI=1 # Force separate caches
       install:
         - go get -d -u ./...
         # Substitute build string
@@ -79,24 +81,9 @@ jobs:
 
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
-      dist: trusty # xenial not available
-      language: android
-      android:
-        components:
-          - android-23
+      env:
+        - BUILD_ANDROID=1 # Force separate caches
       before_script:
-        # Install SDK and accept licenses
-        - yes | sdkmanager "ndk-bundle"
-        - if [ -d "$GOPATH/src/golang.org/x/mobile/cmd/gomobile" ]; then (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard); fi
-        - go get -d -u golang.org/x/mobile/cmd/gomobile
-        # Freeze gomobile version (newer versions break Psiphon code)
-        - (cd $GOPATH/src/golang.org/x/mobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
-        # Binary hashes has since changed
-        - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
-        - sed -i.bak "s/df8492a31030c4a940aa17602ea7ce56eb0759be9235f68fcce4c51150e49881/84c9361734902df622dd49a8c0cfb0090fd7743a2cbf927a9ae85c4826beb173/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
-        - go install golang.org/x/mobile/cmd/gomobile
-        # Initialize gomobile tool
-        - if [ ! -d "$GOPATH/pkg/gomobile" ]; then gomobile init; fi
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg update --clean)
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
@@ -106,10 +93,10 @@ jobs:
         - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
       script:
         # Build Psiphon Android Library ca.psiphon.aar
-        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")
+        - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core:/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core refraction/psiandroid /bin/bash -c 'cd /go/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE"'
         - mv $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/ca.psiphon.aar build/
         # Build Psiphon Android App PsiphonAndroid-debug.apk
         - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/
-        - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug)
-        - mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/
+        - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android:/go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android refraction/psiandroid /bin/bash -c 'yes | /android-sdk-linux/tools/bin/sdkmanager --update && cd /go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug'
+        - sudo mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/
         - rm $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/ca.psiphon.aar

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,8 @@ jobs:
           - tools
           - platform-tools
           - tools
-          - tools
+          - build-tools-28.0.3
+          - android-28
       before_script:
         - yes | sdkmanager "ndk-bundle"
         - go get -u golang.org/x/mobile/cmd/gomobile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,49 +13,52 @@ notifications:
 cache:
   pip: true
   directories:
-    - $GOPATH
-before_cache:
-  - mv $TRAVIS_BUILD_DIR $TRAVIS_HOME/tmp
-  - export TRAVIS_BUILD_DIR=$TRAVIS_HOME/tmp
+    - $TRAVIS_HOME/go
+before_install:
+  - export GOPATH=$TRAVIS_HOME/go
+  - export PATH=$GOPATH/bin:$PATH
+  - mkdir -p $GOPATH/src/github.com/sergeyfrolov
+  - mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/sergeyfrolov/gotapdance
+  - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR
 
 ## Golang Test
 # Go versions: all specified
-# install:
-#   - go get -d -u -t ./...
-#   - go get -u github.com/golang/lint/golint
-#   - go get -u github.com/alecthomas/gometalinter
-#
-# script:
-#   - go test -race -v ./tapdance
-#   - go test -race -v ./tdproxy
-#   - gometalinter --install
-#   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
+install:
+  - go get -d -u -t ./...
+  - go get -u github.com/golang/lint/golint
+  - go get -u github.com/alecthomas/gometalinter
+
+script:
+  - go test -race -v ./tapdance
+  - go test -race -v ./tdproxy
+  - gometalinter --install
+  - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
 ## Build job for CLI, Psiphon ConsoleClient and Android App
 # Go versions: first value in array
-jobs:
-  include:
-    - &build # YAML anchor/alias
-      stage: build
-      name: "Build cli and Psiphon ConsoleClient on Linux"
-      install:
-        - go get -d -u ./...
-        # Substitute build string
-        - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
-        - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-        # Remove gotapdance from vendored packages
-        - go get -u github.com/kardianos/govendor
-        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
-        # Enable TapDance logging
-        - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-      script:
-        - go build -o build/cli-$TRAVIS_OS_NAME ./cli
-        - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-      after_success:
-        # Upload built binaries to S3
-        - pip install --user awscli
-        - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
+# jobs:
+#   include:
+    # - &build # YAML anchor/alias
+    #   stage: build
+    #   name: "Build cli and Psiphon ConsoleClient on Linux"
+    #   install:
+    #     - go get -d -u ./...
+    #     # Substitute build string
+    #     - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
+    #     - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+    #     # Remove gotapdance from vendored packages
+    #     - go get -u github.com/kardianos/govendor
+    #     - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
+    #     # Enable TapDance logging
+    #     - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+    #   script:
+    #     - go build -o build/cli-$TRAVIS_OS_NAME ./cli
+    #     - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+    #   after_success:
+    #     # Upload built binaries to S3
+    #     - pip install --user awscli
+    #     - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
 
     # - <<: *build # Same build on OS X
     #   name: "Build cli and Psiphon ConsoleClient on OS X"

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,12 +83,9 @@ jobs:
           - android-23
       before_script:
         - yes | sdkmanager "ndk-bundle"
-        - go get -d -u golang.org/x/mobile/cmd/gomobile
-        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
-        - mkdir -p $GOPATH/pkg/gomobile/dl
-        - curl -O $GOPATH/pkg/gomobile/dl/gomobile-ndk-r10e-linux-x86_64.tar.gz https://dl.google.com/go/mobile/gomobile-ndk-r10e-linux-x86_64.tar.gz
-        - go install golang.org/x/mobile/cmd/gomobile
+        - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
+        - sed -i.bak "s/import go.psi.Psi;/import psi.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
       dist: trusty # xenial not available
       language: android
       before_script:
-        # Install NDK and accept licenses
+        # Install SDK and accept licenses
         - yes | sdkmanager "tools"
         - yes | sdkmanager "platform-tools" "build-tools;28.0.3" "platforms;android-23" "ndk-bundle"
         - if [ -d "$GOPATH/src/golang.org/x/mobile/cmd/gomobile" ]; then (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
         # Use modified EmbeddedValues.java for TapDance
         - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java
         # Patched tunneling protocol for TapDance
-        - patch -N $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
+        - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch || true
       script:
         # Build Psiphon Android Library ca.psiphon.aar
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ install:
 script:
   - go test -race -v ./tapdance
   - go test -race -v ./tdproxy
+  - gometalinter --install
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - export GOPATH=$TRAVIS_HOME/go
   - export PATH=$GOPATH/bin:$PATH
   - mkdir -p $GOPATH/src/github.com/sergeyfrolov
+  - rm -rf $GOPATH/src/github.com/sergeyfrolov/gotapdance
   - mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/sergeyfrolov/gotapdance
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ env:
   - PATH=$HOME/.local/bin:$PATH
 
 cache:
-  pip: true
   directories:
     - $HOME/.gimme
     - $TRAVIS_HOME/go
+    - $TRAVIS_HOME/android
     - $HOME/.gradle
     - $HOME/.cache/pip
 
@@ -33,6 +33,10 @@ before_install:
   - mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/sergeyfrolov/gotapdance
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR
+  # Move Android tools directory
+  - if [ -z "$ANDROID_HOME" ] && [ ! -d "$TRAVIS_HOME/android/tools" ]; then cp -r $ANDROID_HOME/* $TRAVIS_HOME/android/; fi
+  - export ANDROID_HOME=$TRAVIS_HOME/android
+  - export PATH=$ANDROID_HOME/tools/bin:$PATH
 before_cache:
   # Don't cache gotapdance
   - mv $TRAVIS_BUILD_DIR $TRAVIS_HOME/tmp
@@ -85,16 +89,10 @@ jobs:
       name: "Build Psiphon Android Library and App"
       dist: trusty # xenial not available
       language: android
-      android:
-        components:
-          - tools
-          - platform-tools
-          - tools # Intentional to get latest version
-          - build-tools-28.0.3
-          - android-23 # Target API platform
       before_script:
         # Install NDK and accept licenses
-        - yes | sdkmanager "ndk-bundle"
+        - yes | sdkmanager "tools"
+        - yes | sdkmanager "platform-tools" "build-tools;28.0.3" "platforms;android-23" "ndk-bundle"
         - if [ -d "$GOPATH/src/golang.org/x/mobile/cmd/gomobile" ]; then (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard); fi
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         # Freeze gomobile version (newer versions break Psiphon code)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ go:
   - "1.x"
 
 sudo: required
-dist: bionic
+dist: xenial
 
 notifications:
   slack:
     secure: ZzIEqFE4XRdE9U2p3aeE32DMtoC8RgjoEavhEQ1oLrWFgUpLktqmp9UVY/U+W6iElilLpDbFpry51+Sv9MWpxJMxr+Q/JJuq/3Bj5KjF/wEtil7qvBYhQ1sM/qUQFG6wRkrMNjZGMiaTmnkWF0rZB8lf7+nbnGFaPW3AVVbD+8gVDWTHI4Hcvvgs0UbrJzoPfpvH0dprOchswc1BBKTgo5c44rvS2fquEMVcqMMiNJ5JQqphuRWLTfzLgOzImSf0/xJJyVp/YTkSnVSg8BcWmDCJ4iB9fJkVyZM9WxcgY/J4T5VzFxfMah9zv2j8UTfzHSMeCJDRL647hdnkmr/Qum/LN91Ey2DJw5KUH743CsAbyGhQML6wZ3NCeEP06hnMDphalU5+BYhtAPyc5CB84g6eLIUQ2EqptuPZpjFQohFnapCTnfB5XKTcW+PjxJsoJzk8x+85Xid+H1nnNxeyf10tLv6Pwy4ZGmEEbsa4SYWXibpIEu3fPJXEdtrht0vM40pDLeUYL6Axmh7hNjmDQOXJG41saF+Rk4AArRhKhMQTmlYCc0e1H2/hIDXUMPbqjHeCpEkaA5W8BFBKynhlJa0JX+rtHDFaK82Di8rXT0NO2ACyG8ZQqk87qePyBYPyfR8hRwhrkmQHlYYOZzV6LBz+ynJuWl9ktcC2irJlHZs=
 
-## Golang Test & CLI build
+## Golang Test
 # Go versions: all specified
 install:
   - go get -t ./...
@@ -23,7 +23,7 @@ script:
   - gometalinter --install
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
-## Build job for Psiphon ConsoleClient and Android App
+## Build job for CLI, Psiphon ConsoleClient and Android App
 # Go versions: first value in array
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - go get -u github.com/kardianos/govendor
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
         # Enable TapDance logging
-        - sed -i.bak "s/refraction_networking_tapdance.Logger().Out = ioutil.Discard//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+        - sed -i.bak "s/refraction_networking_tapdance\.Logger()\.Out = ioutil\.Discard//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
       script:
         - go build -o build/cli-$TRAVIS_OS_NAME ./cli
         - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags "TAPDANCE" github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
@@ -85,12 +85,12 @@ jobs:
         - yes | sdkmanager "ndk-bundle"
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
-        - sed -i.bak "s/import go.psi.Psi;/import psi.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi.PsiphonProvider.Stub/psi.PsiphonProvider.Stub/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi.GetPacketTunnelMTU/Psi.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi.GetPacketTunnelDNSResolverIPv4Address/Psi.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi.Start(/Psi.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi.Stop();/Psi.stop();/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/import go\.psi\.Psi;/import psi\.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/psi\.PsiphonProvider\.Stub/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.GetPacketTunnelMTU/Psi\.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.GetPacketTunnelDNSResolverIPv4Address/Psi\.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.Start(/Psi\.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.Stop();/Psi\.stop();/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,7 @@ go:
   - "1.10.x"
   - "1.x"
 
-os: linux
-sudo: required
 dist: xenial
-
-services:
-  - docker
-
-addons:
-  artifacts: true
 
 notifications:
   slack:
@@ -60,22 +52,22 @@ jobs:
       name: "Build cli and Psiphon ConsoleClient on OS X"
       os: osx
 
-    - <<: *build # Reuse setup steps from build
-      name: "Build Psiphon Android Library and App"
-      before_script:
-        # Get Android build environment
-        - docker pull refraction/psiandroid
-        - mkdir -p $GOPATH/src/bitbucket.org/psiphon
-        - hg clone https://bitbucket.org/psiphon/psiphon-circumvention-system $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system
-        # Use modified EmbeddedValues.java for TapDance
-        - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java
-        # Patched tunneling protocol for TapDance
-        - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
-      script:
-        # Build Psiphon Android Library ca.psiphon.aar
-        - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core:/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core refraction/psiandroid /bin/bash -c 'cd /go/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE"'
-        - mv $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/ca.psiphon.aar build/
-        # Build Psiphon Android App PsiphonAndroid-debug.apk
-        - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/
-        - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android:/go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android refraction/psiandroid /bin/bash -c 'yes | /android-sdk-linux/tools/bin/sdkmanager --update && cd /go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug'
-        - sudo mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/
+    # - <<: *build # Reuse setup steps from build
+    #   name: "Build Psiphon Android Library and App"
+    #   before_script:
+    #     # Get Android build environment
+    #     - docker pull refraction/psiandroid
+    #     - mkdir -p $GOPATH/src/bitbucket.org/psiphon
+    #     - hg clone https://bitbucket.org/psiphon/psiphon-circumvention-system $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system
+    #     # Use modified EmbeddedValues.java for TapDance
+    #     - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java
+    #     # Patched tunneling protocol for TapDance
+    #     - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
+    #   script:
+    #     # Build Psiphon Android Library ca.psiphon.aar
+    #     - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core:/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core refraction/psiandroid /bin/bash -c 'cd /go/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE"'
+    #     - mv $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/ca.psiphon.aar build/
+    #     # Build Psiphon Android App PsiphonAndroid-debug.apk
+    #     - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/
+    #     - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android:/go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android refraction/psiandroid /bin/bash -c 'yes | /android-sdk-linux/tools/bin/sdkmanager --update && cd /go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug'
+    #     - sudo mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ jobs:
     - &build # YAML anchor/alias
       stage: build
       name: "Build cli and Psiphon ConsoleClient on Linux"
+      env:
+        - STAGE_BUILD=1 # Force separate caches
       install:
         - go get -d -u ./...
         # Substitute build string

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,16 +74,18 @@ jobs:
 
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
+      language: android
+
       before_script:
-        - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/.hg
-        - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system/Android)
+        - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
+        - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance
         - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java
         # Patched tunneling protocol for TapDance
         - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
       script:
         # Build Psiphon Android Library ca.psiphon.aar
-        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")
+    #     - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")
     #     - mv $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/ca.psiphon.aar build/
     #     # Build Psiphon Android App PsiphonAndroid-debug.apk
     #     - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - sed -i.bak "s/import go\.psi\.Psi;/import psi\.Psi;/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
-        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/psi\.PsiphonProvider\.Stub/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
+        - sed -i.bak "s/Psi\.PsiphonProvider\.Stub/psi\.PsiphonProvider/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelMTU/Psi\.getPacketTunnelMTU/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.GetPacketTunnelDNSResolverIPv4Address/Psi\.getPacketTunnelDNSResolverIPv4Address/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java
         - sed -i.bak "s/Psi\.Start(/Psi\.start(/" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/PsiphonTunnel/PsiphonTunnel.java

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
       before_script:
         - yes | sdkmanager "ndk-bundle"
         - go get -d -u golang.org/x/mobile/cmd/gomobile
-        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 74ee969d3ffc95befa9a96a6590c36d71b6afd52)
+        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard d6153aa12bff20a59a59a08b68ecf806b3a60605)
         - go install golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 script:
   - go test -race -v ./tapdance
   - go test -race -v ./tdproxy
-  - if [ ! -f "$GOPATH/bin/misspell" ] || [ ! -f "$GOPATH/bin/ineffassign" ] || [ ! -f "$GOPATH/bin/deadcode" ]; then gometalinter --install; fi
+  - gometalinter --install
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,16 @@ notifications:
   slack:
     secure: ZzIEqFE4XRdE9U2p3aeE32DMtoC8RgjoEavhEQ1oLrWFgUpLktqmp9UVY/U+W6iElilLpDbFpry51+Sv9MWpxJMxr+Q/JJuq/3Bj5KjF/wEtil7qvBYhQ1sM/qUQFG6wRkrMNjZGMiaTmnkWF0rZB8lf7+nbnGFaPW3AVVbD+8gVDWTHI4Hcvvgs0UbrJzoPfpvH0dprOchswc1BBKTgo5c44rvS2fquEMVcqMMiNJ5JQqphuRWLTfzLgOzImSf0/xJJyVp/YTkSnVSg8BcWmDCJ4iB9fJkVyZM9WxcgY/J4T5VzFxfMah9zv2j8UTfzHSMeCJDRL647hdnkmr/Qum/LN91Ey2DJw5KUH743CsAbyGhQML6wZ3NCeEP06hnMDphalU5+BYhtAPyc5CB84g6eLIUQ2EqptuPZpjFQohFnapCTnfB5XKTcW+PjxJsoJzk8x+85Xid+H1nnNxeyf10tLv6Pwy4ZGmEEbsa4SYWXibpIEu3fPJXEdtrht0vM40pDLeUYL6Axmh7hNjmDQOXJG41saF+Rk4AArRhKhMQTmlYCc0e1H2/hIDXUMPbqjHeCpEkaA5W8BFBKynhlJa0JX+rtHDFaK82Di8rXT0NO2ACyG8ZQqk87qePyBYPyfR8hRwhrkmQHlYYOZzV6LBz+ynJuWl9ktcC2irJlHZs=
 
+cache:
+  directories:
+    - $GOPATH
+
 ## Golang Test
 # Go versions: all specified
 install:
-  - go get -t ./...
-  - go get github.com/golang/lint/golint
-  - go get github.com/alecthomas/gometalinter
+  - go get -u -t ./...
+  - go get -u github.com/golang/lint/golint
+  - go get -u github.com/alecthomas/gometalinter
 
 script:
   - go test -race -v ./tapdance
@@ -31,13 +35,13 @@ jobs:
       stage: build
       name: "Build cli and Psiphon ConsoleClient on Linux"
       install:
-        - go get ./...
+        - go get -u ./...
         # Substitute build string
         - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
         - mkdir -p $GOPATH/src/github.com/Psiphon-Labs
         - git clone https://github.com/Psiphon-Labs/psiphon-tunnel-core.git $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core
         # Remove gotapdance from vendored packages
-        - go get github.com/kardianos/govendor
+        - go get -u github.com/kardianos/govendor
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
         # Enable TapDance logging
         - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,22 +22,26 @@ before_install:
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR
 before_cache:
+  - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && git reset --hard HEAD && git clean -df)
+  - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && hg update --clean && hg purge)
   - mv $TRAVIS_BUILD_DIR $TRAVIS_HOME/tmp
   - export TRAVIS_BUILD_DIR=$TRAVIS_HOME/tmp
   - cd $TRAVIS_BUILD_DIR
 
 ## Golang Test
 # Go versions: all specified
-install:
-  - go get -d -u -t ./...
-  - go get -u github.com/golang/lint/golint
-  - go get -u github.com/alecthomas/gometalinter
-
-script:
-  - go test -race -v ./tapdance
-  - go test -race -v ./tdproxy
-  - gometalinter --install
-  - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
+# install:
+#   - go get -d -u -t ./...
+#   - go get -u github.com/golang/lint/golint
+#   - go get -u github.com/alecthomas/gometalinter
+#
+# script:
+#   - go test -race -v ./tapdance
+#   - go test -race -v ./tdproxy
+#   - gometalinter --install
+#   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
+install: skip
+script: skip
 
 ## Build job for CLI, Psiphon ConsoleClient and Android App
 # Go versions: first value in array
@@ -50,40 +54,38 @@ jobs:
         - go get -d -u ./...
         # Substitute build string
         - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
-        - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+        - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon
         # Remove gotapdance from vendored packages
         - go get -u github.com/kardianos/govendor
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
         # Enable TapDance logging
-        - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+        - sed -i.bak "s/refraction_networking_tapdance.Logger().Out = ioutil.Discard//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
       script:
         - go build -o build/cli-$TRAVIS_OS_NAME ./cli
-        - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+        - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags "TAPDANCE" github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
       after_success:
         # Upload built binaries to S3
         - pip install --user awscli
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
+    #
+    # - <<: *build # Same build on OS X
+    #   name: "Build cli and Psiphon ConsoleClient on OS X"
+    #   os: osx
 
-    - <<: *build # Same build on OS X
-      name: "Build cli and Psiphon ConsoleClient on OS X"
-      os: osx
-
-    # - <<: *build # Reuse setup steps from build
-    #   name: "Build Psiphon Android Library and App"
-    #   before_script:
-    #     # Get Android build environment
-    #     - docker pull refraction/psiandroid
-    #     - mkdir -p $GOPATH/src/bitbucket.org/psiphon
-    #     - hg clone https://bitbucket.org/psiphon/psiphon-circumvention-system $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system
-    #     # Use modified EmbeddedValues.java for TapDance
-    #     - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java
-    #     # Patched tunneling protocol for TapDance
-    #     - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
-    #   script:
-    #     # Build Psiphon Android Library ca.psiphon.aar
-    #     - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core:/go/src/github.com/Psiphon-Labs/psiphon-tunnel-core refraction/psiandroid /bin/bash -c 'cd /go/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE"'
+    - <<: *build # Reuse setup steps from build
+      name: "Build Psiphon Android Library and App"
+      before_script:
+        - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/.hg
+        - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system/Android)
+        # Use modified EmbeddedValues.java for TapDance
+        - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java
+        # Patched tunneling protocol for TapDance
+        - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
+      script:
+        # Build Psiphon Android Library ca.psiphon.aar
+        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")
     #     - mv $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android/ca.psiphon.aar build/
     #     # Build Psiphon Android App PsiphonAndroid-debug.apk
     #     - cp build/ca.psiphon.aar $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/libs/
-    #     - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android:/go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android refraction/psiandroid /bin/bash -c 'yes | /android-sdk-linux/tools/bin/sdkmanager --update && cd /go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug'
+    #     - docker run -v $TRAVIS_BUILD_DIR:/go/src/github.com/sergeyfrolov/gotapdance -v $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android:/go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android refraction/psiandroid /bin/bash -c "yes | /android-sdk-linux/tools/bin/sdkmanager --update && cd /go/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && ./gradlew assembleDebug"
     #     - sudo mv $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/build/outputs/apk/debug/PsiphonAndroid-debug.apk build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
   directories:
     - $HOME/.gimme
     - $TRAVIS_HOME/go
-    - $TRAVIS_HOME/android
     - $HOME/.gradle
     - $HOME/.local
 
@@ -30,10 +29,6 @@ before_install:
   - mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/sergeyfrolov/gotapdance
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR
-  # Move Android tools directory
-  - if [ ! -z "$ANDROID_HOME" ] && [ ! -d "$TRAVIS_HOME/android/tools" ]; then cp -r $ANDROID_HOME/* $TRAVIS_HOME/android/; fi
-  - export ANDROID_HOME=$TRAVIS_HOME/android
-  - export PATH=$ANDROID_HOME/tools/bin:$PATH
 before_cache:
   # Don't cache gotapdance
   - mv $TRAVIS_BUILD_DIR $TRAVIS_HOME/tmp
@@ -71,7 +66,7 @@ jobs:
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
         # Enable TapDance logging
         - sed -i.bak "s/refraction_networking_tapdance\.Logger()\.Out = ioutil\.Discard//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-        - pip install --user --upgrade pip
+        - virtualenv -p  .
         - pip install --user --upgrade awscli
       script:
         - go build -o build/cli-$TRAVIS_OS_NAME ./cli
@@ -88,10 +83,16 @@ jobs:
       name: "Build Psiphon Android Library and App"
       dist: trusty # xenial not available
       language: android
+      android:
+        components:
+          - tools
+          - platform-tools
+          - tools
+          - build-tools-28.0.3
+          - android-23
       before_script:
         # Install SDK and accept licenses
-        - yes | sdkmanager "tools"
-        - yes | sdkmanager "platform-tools" "build-tools;28.0.3" "platforms;android-23" "ndk-bundle"
+        - yes | sdkmanager "ndk-bundle"
         - if [ -d "$GOPATH/src/golang.org/x/mobile/cmd/gomobile" ]; then (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard); fi
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         # Freeze gomobile version (newer versions break Psiphon code)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,8 @@ cache:
   directories:
     - $GOPATH
 before_cache:
-  - cp -r ${TRAVIS_BUILD_DIR} ${TRAVIS_HOME}/tmp
+  - echo ${TRAVIS_BUILD_DIR}
   - rm -rf ${TRAVIS_BUILD_DIR}
-  - export TRAVIS_BUILD_DIR=${TRAVIS_HOME}/tmp
-  - cd ${TRAVIS_BUILD_DIR}
 
 ## Golang Test
 # Go versions: all specified

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+env:
+  - GIMME_GO_VERSION=1.10.x
+  - GIMME_GO_VERSION=1.x
+
 sudo: required
 dist: xenial
 
@@ -26,6 +30,7 @@ before_cache:
 ## Golang Test
 # Go versions: all specified
 install:
+  - eval "$(gimme)"
   - go get -d -u -t ./...
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/alecthomas/gometalinter

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
     - $HOME/.gimme
     - $TRAVIS_HOME/go
     - $HOME/.gradle
+    - $HOME/.cache/pip
 
 notifications:
   slack:
@@ -43,12 +44,10 @@ before_cache:
 # Go versions: all specified
 install:
   - go get -d -u -t ./...
-  - go get -u github.com/golang/lint/golint
   - go get -u github.com/alecthomas/gometalinter
 script:
   - go test -race -v ./tapdance
   - go test -race -v ./tdproxy
-  - gometalinter --install
   - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode --tests ./tapdance
 
 
@@ -99,13 +98,13 @@ jobs:
         - if [ -d "$GOPATH/src/golang.org/x/mobile/cmd/gomobile" ]; then (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard); fi
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         # Freeze gomobile version (newer versions break Psiphon code)
-        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git checkout -b pinned 320ec40f6328971c405979b804e20d5f3c86770c)
+        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
         # Binary hashes has since changed
         - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - sed -i.bak "s/df8492a31030c4a940aa17602ea7ce56eb0759be9235f68fcce4c51150e49881/84c9361734902df622dd49a8c0cfb0090fd7743a2cbf927a9ae85c4826beb173/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - go install golang.org/x/mobile/cmd/gomobile
         # Initialize gomobile tool
-        - gomobile init
+        - if [ ! -d "$GOPATH/pkg/gomobile" ]; then gomobile init; fi
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg update --clean)
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,12 +74,12 @@ jobs:
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
         # Enable TapDance logging
         - sed -i.bak "s/refraction_networking_tapdance\.Logger()\.Out = ioutil\.Discard//" $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+        - pip install --user awscli
       script:
         - go build -o build/cli-$TRAVIS_OS_NAME ./cli
         - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags "TAPDANCE" github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
       after_success:
         # Upload built binaries to S3
-        - pip install --user awscli
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$AWS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
 
     - <<: *build # Same build on OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ before_install:
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR
 before_cache:
-  - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && git reset --hard HEAD && git clean -df)
-  - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android && hg update --clean && hg purge)
   - mv $TRAVIS_BUILD_DIR $TRAVIS_HOME/tmp
   - export TRAVIS_BUILD_DIR=$TRAVIS_HOME/tmp
   - cd $TRAVIS_BUILD_DIR
@@ -74,6 +72,7 @@ jobs:
 
     - <<: *build # Reuse setup steps from build
       name: "Build Psiphon Android Library and App"
+      language: android
       before_script:
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
@@ -82,7 +81,7 @@ jobs:
         # Use modified EmbeddedValues.java for TapDance
         - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java
         # Patched tunneling protocol for TapDance
-        - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
+        - patch -N $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
       script:
         # Build Psiphon Android Library ca.psiphon.aar
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: generic
-
-env:
-  - GIMME_GO_VERSION=1.10.x
-  - GIMME_GO_VERSION=1.x
+language: go
+go:
+  - "1.10.x"
+  - "1.x"
 
 sudo: required
 dist: xenial
@@ -12,7 +11,7 @@ notifications:
     secure: ZzIEqFE4XRdE9U2p3aeE32DMtoC8RgjoEavhEQ1oLrWFgUpLktqmp9UVY/U+W6iElilLpDbFpry51+Sv9MWpxJMxr+Q/JJuq/3Bj5KjF/wEtil7qvBYhQ1sM/qUQFG6wRkrMNjZGMiaTmnkWF0rZB8lf7+nbnGFaPW3AVVbD+8gVDWTHI4Hcvvgs0UbrJzoPfpvH0dprOchswc1BBKTgo5c44rvS2fquEMVcqMMiNJ5JQqphuRWLTfzLgOzImSf0/xJJyVp/YTkSnVSg8BcWmDCJ4iB9fJkVyZM9WxcgY/J4T5VzFxfMah9zv2j8UTfzHSMeCJDRL647hdnkmr/Qum/LN91Ey2DJw5KUH743CsAbyGhQML6wZ3NCeEP06hnMDphalU5+BYhtAPyc5CB84g6eLIUQ2EqptuPZpjFQohFnapCTnfB5XKTcW+PjxJsoJzk8x+85Xid+H1nnNxeyf10tLv6Pwy4ZGmEEbsa4SYWXibpIEu3fPJXEdtrht0vM40pDLeUYL6Axmh7hNjmDQOXJG41saF+Rk4AArRhKhMQTmlYCc0e1H2/hIDXUMPbqjHeCpEkaA5W8BFBKynhlJa0JX+rtHDFaK82Di8rXT0NO2ACyG8ZQqk87qePyBYPyfR8hRwhrkmQHlYYOZzV6LBz+ynJuWl9ktcC2irJlHZs=
 
 cache:
-  # pip: true
+  pip: true
   directories:
     - $TRAVIS_HOME/go
 before_install:
@@ -30,7 +29,6 @@ before_cache:
 ## Golang Test
 # Go versions: all specified
 install:
-  - eval "$(gimme)"
   - go get -d -u -t ./...
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/alecthomas/gometalinter
@@ -43,32 +41,32 @@ script:
 
 ## Build job for CLI, Psiphon ConsoleClient and Android App
 # Go versions: first value in array
-# jobs:
-#   include:
-    # - &build # YAML anchor/alias
-    #   stage: build
-    #   name: "Build cli and Psiphon ConsoleClient on Linux"
-    #   install:
-    #     - go get -d -u ./...
-    #     # Substitute build string
-    #     - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
-    #     - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-    #     # Remove gotapdance from vendored packages
-    #     - go get -u github.com/kardianos/govendor
-    #     - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
-    #     # Enable TapDance logging
-    #     - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
-    #   script:
-    #     - go build -o build/cli-$TRAVIS_OS_NAME ./cli
-    #     - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
-    #   after_success:
-    #     # Upload built binaries to S3
-    #     - pip install --user awscli
-    #     - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
-    #
-    # - <<: *build # Same build on OS X
-    #   name: "Build cli and Psiphon ConsoleClient on OS X"
-    #   os: osx
+jobs:
+  include:
+    - &build # YAML anchor/alias
+      stage: build
+      name: "Build cli and Psiphon ConsoleClient on Linux"
+      install:
+        - go get -d -u ./...
+        # Substitute build string
+        - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
+        - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+        # Remove gotapdance from vendored packages
+        - go get -u github.com/kardianos/govendor
+        - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && govendor remove github.com/sergeyfrolov/gotapdance/...)
+        # Enable TapDance logging
+        - sed -i.bak 's/refraction_networking_tapdance.Logger().Out = ioutil.Discard//' $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/tapdance/tapdance.go
+      script:
+        - go build -o build/cli-$TRAVIS_OS_NAME ./cli
+        - go build -o build/ConsoleClient-$TRAVIS_OS_NAME -tags 'TAPDANCE' github.com/Psiphon-Labs/psiphon-tunnel-core/ConsoleClient
+      after_success:
+        # Upload built binaries to S3
+        - pip install --user awscli
+        - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync build s3://$ARTIFACTS_BUCKET/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH/; fi
+
+    - <<: *build # Same build on OS X
+      name: "Build cli and Psiphon ConsoleClient on OS X"
+      os: osx
 
     # - <<: *build # Reuse setup steps from build
     #   name: "Build Psiphon Android Library and App"

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,9 @@ jobs:
           - tools
           - platform-tools
           - tools
-          - ndk-bundle
+          - tools
       before_script:
+        - yes | sdkmanager "ndk-bundle"
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   directories:
     - $TRAVIS_HOME/go
 before_install:
-  - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.9.6 bash)"; fi
+  - if [ -z "$TRAVIS_GO_VERSION" ]; then eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"; fi
   - export GOPATH=$TRAVIS_HOME/go
   - export PATH=$GOPATH/bin:$PATH
   - mkdir -p $GOPATH/src/github.com/sergeyfrolov
@@ -83,6 +83,7 @@ jobs:
           - android-23
       before_script:
         - yes | sdkmanager "ndk-bundle"
+        - export CGO_ENABLED=1
         - go get -u golang.org/x/mobile/cmd/gomobile
         - gomobile init
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,11 @@ before_install:
   - export GOPATH=$TRAVIS_HOME/go
   - export PATH=$GOPATH/bin:$PATH
   - mkdir -p $GOPATH/src/github.com/sergeyfrolov
-  - rm -rf $GOPATH/src/github.com/sergeyfrolov/gotapdance
+  - mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/sergeyfrolov/gotapdance
+  - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
+  - cd $TRAVIS_BUILD_DIR
+before_cache:
+  - export GOPATH=$TRAVIS_HOME/gopath
   - mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/sergeyfrolov/gotapdance
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/sergeyfrolov/gotapdance
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,9 @@ jobs:
       language: android
       android:
         components:
+          - tools
+          - platform-tools
+          - tools
           - ndk-bundle
       before_script:
         - go get -u golang.org/x/mobile/cmd/gomobile

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
         - go get -d -u ./...
         # Substitute build string
         - sed -i.bak "s/\[BUILD\]/$TRAVIS_BRANCH-$TRAVIS_COMMIT/" tapdance/logger.go
+        - if [ -d "$GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core" ]; then (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core && git reset --hard); fi
         - go get -d -u github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon
         # Remove gotapdance from vendored packages
         - go get -u github.com/kardianos/govendor
@@ -88,21 +89,23 @@ jobs:
       before_script:
         # Install NDK and accept licenses
         - yes | sdkmanager "ndk-bundle"
+        - if [ -d "$GOPATH/src/golang.org/x/mobile/cmd/gomobile" ]; then (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard); fi
         - go get -d -u golang.org/x/mobile/cmd/gomobile
         # Freeze gomobile version (newer versions break Psiphon code)
-        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git reset --hard 320ec40f6328971c405979b804e20d5f3c86770c)
+        - (cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile && git checkout -b pinned 320ec40f6328971c405979b804e20d5f3c86770c)
         # Binary hashes has since changed
         - sed -i.bak "s/709d96f5234c224e4b72254fd2e196d0e1486b8d943e972ed98cf14e3ca7bdde/bacfed664a7b69b1b693f246ea49a85f04f502bd1ae723351c5345ab5b2ba850/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - sed -i.bak "s/df8492a31030c4a940aa17602ea7ce56eb0759be9235f68fcce4c51150e49881/84c9361734902df622dd49a8c0cfb0090fd7743a2cbf927a9ae85c4826beb173/" $GOPATH/src/golang.org/x/mobile/cmd/gomobile/hashes.go
         - go install golang.org/x/mobile/cmd/gomobile
         # Initialize gomobile tool
         - gomobile init
+        - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg update --clean)
         - mkdir -p $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/.hg
         - (cd $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system && hg pull -u -b default https://bitbucket.org/psiphon/psiphon-circumvention-system)
         # Use modified EmbeddedValues.java for TapDance
         - openssl aes-256-cbc -d -K $encrypted_8a9748c534c1_key -iv $encrypted_8a9748c534c1_iv -in build/EmbeddedValues.java.enc -out $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/EmbeddedValues.java
         # Patched tunneling protocol for TapDance
-        - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch || true
+        - patch $GOPATH/src/bitbucket.org/psiphon/psiphon-circumvention-system/Android/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java build/TunnelManager.java.patch
       script:
         # Build Psiphon Android Library ca.psiphon.aar
         - (cd $GOPATH/src/github.com/Psiphon-Labs/psiphon-tunnel-core/MobileLibrary/Android && ./make.bash "TAPDANCE")


### PR DESCRIPTION
These changes speed up subsequent builds by around 1.35x (~23 → ~17 mins) while focusing on maintainability: 

- Natively build Android library and app without pulling Docker container
- Cache everything in GOPATH except gotapdance between builds
- Cache Gradle download cache