### PR TITLE
Fix: #84 Use bytes.Buffer to store protobuf message

### DIFF
--- a/tapdance/conn_raw.go
+++ b/tapdance/conn_raw.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	pb "github.com/sergeyfrolov/gotapdance/protobuf"
 	"io"
-	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -407,74 +406,50 @@ func (tdRaw *tdRawConn) idStr() string {
 // Simply reads and returns protobuf
 // Returns error if it's not a protobuf
 func (tdRaw *tdRawConn) readProto() (msg pb.StationToClient, err error) {
-	var readBytes int
-	var copiedBytes int64
-	var readBytesTotal uint32 // both header and body
-	headerSize := uint32(2)
+	var readBuffer bytes.Buffer
 
-	var msgLen uint32 // just the body(e.g. raw data or protobuf)
 	var outerProtoMsgType msgType
-
-	headerBuffer := make([]byte, 6) // TODO: allocate once at higher level?
-
-	for readBytesTotal < headerSize {
-		readBytes, err = tdRaw.tlsConn.Read(headerBuffer[readBytesTotal:headerSize])
-		readBytesTotal += uint32(readBytes)
-		if err != nil {
-			return
-		}
-	}
+	var msgLen int64 // just the body (e.g. raw data or protobuf)
 
 	// Get TIL
-	typeLen := uint16toInt16(binary.BigEndian.Uint16(headerBuffer[0:2]))
+	_, err = io.CopyN(&readBuffer, tdRaw.tlsConn, 2)
+	if err != nil {
+		return
+	}
+
+	typeLen := uint16toInt16(binary.BigEndian.Uint16(readBuffer.Next(2)))
 	if typeLen < 0 {
 		outerProtoMsgType = msgRawData
-		msgLen = uint32(-typeLen)
+		msgLen = int64(-typeLen)
 	} else if typeLen > 0 {
 		outerProtoMsgType = msgProtobuf
-		msgLen = uint32(typeLen)
+		msgLen = int64(typeLen)
 	} else {
 		// protobuf with size over 32KB, not fitting into 2-byte TL
 		outerProtoMsgType = msgProtobuf
-		headerSize += 4
-		for readBytesTotal < headerSize {
-			readBytes, err = tdRaw.tlsConn.Read(headerBuffer[readBytesTotal:headerSize])
-
-			readBytesTotal += uint32(readBytes)
-			if err == io.EOF && readBytesTotal == headerSize {
-				break
-			}
-			if err != nil {
-				return
-			}
+		_, err = io.CopyN(&readBuffer, tdRaw.tlsConn, 4)
+		if err != nil {
+			return
 		}
-		msgLen = binary.BigEndian.Uint32(headerBuffer[2:6])
+		msgLen = int64(binary.BigEndian.Uint32(readBuffer.Next(4)))
 	}
+
 	if outerProtoMsgType == msgRawData {
 		err = errors.New("Received data message in uninitialized flow")
 		return
 	}
 
-	totalBytesToRead := headerSize + msgLen
-	var readBuffer bytes.Buffer
-
 	// Get the message itself
-	for readBytesTotal < totalBytesToRead {
-		copiedBytes, err = io.CopyN(&readBuffer, tdRaw.tlsConn, int64(totalBytesToRead-readBytesTotal))
-		if copiedBytes > math.MaxUint32 {
-			panic("copiedBytes > MaxUint32")
-		}
-		readBytesTotal += uint32(copiedBytes)
-
-		if err != nil {
-			return
-		}
+	_, err = io.CopyN(&readBuffer, tdRaw.tlsConn, msgLen)
+	if err != nil {
+		return
 	}
 
 	err = proto.Unmarshal(readBuffer.Bytes(), &msg)
 	if err != nil {
 		return
 	}
+
 	Logger().Debugln(tdRaw.idStr() + " INIT: received protobuf: " + msg.String())
 	return
 }


### PR DESCRIPTION
So we don't have to pre-allocate a potentially huge byte slice based on the assumed msgLen