### PR TITLE
Fix data races

### DIFF
--- a/tapdance/assets.go
+++ b/tapdance/assets.go
@@ -286,6 +286,8 @@ func (a *assets) SetDecoys(decoys []*pb.TLSDecoySpec) (err error) {
 func (a *assets) IsDecoyInList(decoy pb.TLSDecoySpec) bool {
 	ipv4str := decoy.GetIpAddrStr()
 	hostname := decoy.GetHostname()
+	a.RLock()
+	defer a.RUnlock()
 	for _, d := range a.config.GetDecoyList().GetTlsDecoys() {
 		if strings.Compare(d.GetHostname(), hostname) == 0 &&
 			strings.Compare(d.GetIpAddrStr(), ipv4str) == 0 {

--- a/tapdance/counter.go
+++ b/tapdance/counter.go
@@ -5,7 +5,7 @@ import "sync"
 // CounterUint64 is a goroutine-safe uint64 counter.
 // Wraps, if underflows/overflows.
 type CounterUint64 struct {
-	sync.Mutex
+	sync.RWMutex
 	value uint64
 }
 
@@ -25,13 +25,14 @@ func (c *CounterUint64) Inc() uint64 {
 // GetAndInc returns current value and then increases the counter
 func (c *CounterUint64) GetAndInc() uint64 {
 	c.Lock()
-	defer c.Unlock()
+	retVal := c.value
 	if c.value == ^uint64(0) {
 		// if max
 		c.value = 0
+	} else {
+		c.value++
 	}
-	retVal := c.value
-	c.value++
+	c.Unlock()
 	return retVal
 }
 
@@ -49,8 +50,16 @@ func (c *CounterUint64) Dec() uint64 {
 
 // Get returns current counter value
 func (c *CounterUint64) Get() (value uint64) {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
 	value = c.value
+	c.RUnlock()
+	return
+}
+
+// Set assigns current counter value
+func (c *CounterUint64) Set(value uint64) {
+	c.Lock()
+	c.value = value
+	c.Unlock()
 	return
 }


### PR DESCRIPTION
 * Locks assets (and decoy list) while checking IsDecoyInList()
 * Optimizes goroutine-safe CounterUint64, and uses it for flow ID